### PR TITLE
Allow inner joins to be defined as lazy

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -22,12 +22,18 @@
          },
          "IncrementInteger": {
              "ignore": [
-                 "WyriHaximus\\React\\SimpleORM\\Repository::count"
+                 "WyriHaximus\\React\\SimpleORM\\Repository::count",
+                 "WyriHaximus\\React\\SimpleORM\\Repository::buildTree"
              ]
          },
          "OneZeroInteger": {
              "ignore": [
                  "WyriHaximus\\React\\SimpleORM\\Repository::count"
+             ]
+         },
+         "Foreach_": {
+             "ignore": [
+                 "WyriHaximus\\React\\SimpleORM\\Repository::buildTree"
              ]
          }
      }

--- a/src/Annotation/InnerJoin.php
+++ b/src/Annotation/InnerJoin.php
@@ -20,6 +20,9 @@ final class InnerJoin implements JoinInterface
     /** @var string */
     private $property;
 
+    /** @var bool */
+    private $lazy = self::IS_NOT_LAZY;
+
     public function __construct(array $table)
     {
         /** @psalm-suppress RawObjectIteration */
@@ -38,6 +41,11 @@ final class InnerJoin implements JoinInterface
     public function getType(): string
     {
         return 'inner';
+    }
+
+    public function getLazy(): bool
+    {
+        return $this->lazy;
     }
 
     /**

--- a/src/Annotation/JoinInterface.php
+++ b/src/Annotation/JoinInterface.php
@@ -4,11 +4,16 @@ namespace WyriHaximus\React\SimpleORM\Annotation;
 
 interface JoinInterface
 {
+    public const IS_LAZY = true;
+    public const IS_NOT_LAZY = false;
+
     public function getEntity(): string;
 
     public function getType(): string;
 
     public function getProperty(): string;
+
+    public function getLazy(): bool;
 
     /**
      * @return Clause[]

--- a/src/Annotation/LeftJoin.php
+++ b/src/Annotation/LeftJoin.php
@@ -20,6 +20,9 @@ final class LeftJoin implements JoinInterface
     /** @var string */
     private $property;
 
+    /** @var bool */
+    private $lazy = self::IS_NOT_LAZY;
+
     public function __construct(array $table)
     {
         /** @psalm-suppress RawObjectIteration */
@@ -38,6 +41,11 @@ final class LeftJoin implements JoinInterface
     public function getType(): string
     {
         return 'left';
+    }
+
+    public function getLazy(): bool
+    {
+        return $this->lazy;
     }
 
     /**

--- a/src/Entity/Join.php
+++ b/src/Entity/Join.php
@@ -16,14 +16,18 @@ final class Join
     /** @var string */
     private $property;
 
+    /** @var bool */
+    private $lazy;
+
     /** @var Clause[] */
     private $clause;
 
-    public function __construct(InspectedEntityInterface $entity, string $type, string $property, Clause ...$clause)
+    public function __construct(InspectedEntityInterface $entity, string $type, string $property, bool $lazy, Clause ...$clause)
     {
         $this->entity = $entity;
         $this->type = $type;
         $this->property = $property;
+        $this->lazy = $lazy;
         $this->clause = $clause;
     }
 
@@ -40,6 +44,11 @@ final class Join
     public function getProperty(): string
     {
         return $this->property;
+    }
+
+    public function getLazy(): bool
+    {
+        return $this->lazy;
     }
 
     /**

--- a/src/EntityInspector.php
+++ b/src/EntityInspector.php
@@ -80,6 +80,7 @@ final class EntityInspector
                 new LazyInspectedEntity($this, $annotation->getEntity()),
                 $annotation->getType(),
                 $annotation->getProperty(),
+                $annotation->getLazy(),
                 ...$annotation->getClause()
             );
         }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -167,6 +167,38 @@ final class FunctionalTest extends AsyncTestCase
     /**
      * @test
      */
+    public function firstBlogPostNextBlogPostResolvesToBlogPost(): void
+    {
+        self::assertInstanceOf(
+            BlogPostStub::class,
+            $this->await(
+                $this->client->getRepository(BlogPostStub::class)->fetch()->take(1)->toPromise()->then(function (BlogPostStub $blogPost) {
+                    return $blogPost->getNextBlogPost();
+                }),
+                $this->loop
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function firstBlogPostPreviousBlogPostResolvesToNull(): void
+    {
+        self::assertSame(
+            null,
+            $this->await(
+                $this->client->getRepository(BlogPostStub::class)->fetch()->take(1)->toPromise()->then(function (BlogPostStub $blogPost) {
+                    return $blogPost->getPreviousBlogPost();
+                }),
+                $this->loop
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
     public function secondBlogPostCommentCount(): void
     {
         self::assertCount(

--- a/tests/Stub/BlogPostStub.php
+++ b/tests/Stub/BlogPostStub.php
@@ -21,7 +21,8 @@ use WyriHaximus\React\SimpleORM\EntityInterface;
                 foreign_key="blog_post_id",
             )
         },
-        property="comments"
+        property="comments",
+        lazy=LeftJoin::IS_LAZY
  * )
  * @InnerJoin(
         entity=UserStub::class,
@@ -31,7 +32,8 @@ use WyriHaximus\React\SimpleORM\EntityInterface;
                 foreign_key="id",
             )
         },
-        property="author"
+        property="author",
+        lazy=InnerJoin::IS_NOT_LAZY
  * )
  * @InnerJoin(
         entity=UserStub::class,
@@ -41,7 +43,8 @@ use WyriHaximus\React\SimpleORM\EntityInterface;
                 foreign_key="id",
             )
         },
-        property="publisher"
+        property="publisher",
+        lazy=InnerJoin::IS_NOT_LAZY
  * )
  * @InnerJoin(
         entity=BlogPostStub::class,
@@ -51,7 +54,8 @@ use WyriHaximus\React\SimpleORM\EntityInterface;
                 foreign_key="id",
            )
         },
-        property="previous_blog_post"
+        property="previous_blog_post",
+        lazy=InnerJoin::IS_LAZY
  * )
  * @InnerJoin(
         entity=BlogPostStub::class,
@@ -61,7 +65,8 @@ use WyriHaximus\React\SimpleORM\EntityInterface;
                 foreign_key="id",
             )
         },
-        property="next_blog_post"
+        property="next_blog_post",
+       lazy=InnerJoin::IS_NOT_LAZY
  * )
  */
 class BlogPostStub implements EntityInterface


### PR DESCRIPTION
When an inner join is lazy the data won't be fetched until requested.