### PR TITLE
Disable automatic datetime conversion

### DIFF
--- a/tests/EntityInspectorTest.php
+++ b/tests/EntityInspectorTest.php
@@ -6,7 +6,6 @@ namespace WyriHaximus\React\Tests\SimpleORM;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use RuntimeException;
-use Safe\DateTimeImmutable;
 use WyriHaximus\AsyncTestUtilities\AsyncTestCase;
 use WyriHaximus\React\SimpleORM\EntityInspector;
 use WyriHaximus\React\Tests\SimpleORM\Stub\BlogPostStub;
@@ -67,8 +66,8 @@ final class EntityInspectorTest extends AsyncTestCase
                 'title' => 'string',
                 'contents' => 'string',
                 'views' => 'int',
-                'created' => DateTimeImmutable::class,
-                'modified' => DateTimeImmutable::class,
+                'created' => 'string',
+                'modified' => 'string',
             ] as $key => $type
         ) {
             self::assertArrayHasKey($key, $fields, $key);

--- a/tests/Stub/BlogPostStub.php
+++ b/tests/Stub/BlogPostStub.php
@@ -105,9 +105,9 @@ final class BlogPostStub implements EntityInterface
 
     protected int $views;
 
-    protected DateTimeImmutable $created;
+    protected string $created;
 
-    protected DateTimeImmutable $modified;
+    protected string $modified;
     //phpcs:enable
 
     public function id(): string
@@ -169,11 +169,11 @@ final class BlogPostStub implements EntityInterface
 
     public function getCreated(): DateTimeImmutable
     {
-        return $this->created;
+        return new DateTimeImmutable($this->created);
     }
 
     public function getModified(): DateTimeImmutable
     {
-        return $this->modified;
+        return new DateTimeImmutable($this->modified);
     }
 }


### PR DESCRIPTION
This should be done on the entity's getter when someone needs it

Signed-off-by: Cees-Jan Kiewiet <ceesjank@gmail.com>